### PR TITLE
allow for ks tmp override

### DIFF
--- a/ecephys_spike_sorting/utils/path_collector.py
+++ b/ecephys_spike_sorting/utils/path_collector.py
@@ -49,7 +49,10 @@ def build_attributes_dict(attributes_path):
         'sglx_tools_pdict': _attr_dict["sglx_tools_path_dict"],
         'ks': {
             'versions': _attr_dict["ks_vers_path_dict"],
-            'out_tmp': _attr_dict["ks_output_tmp"]
+            'out_tmp': os.environ.get(
+                "KS_OUT_TMP_OVERRIDE",
+                _attr_dict["ks_output_tmp"]
+            )
         },
     }
 


### PR DESCRIPTION
Running ecephys on a computing cluster means that things written to the ks temp directory will collide. This provides flexibility to the user w/o compromising functionality. 